### PR TITLE
Styling fixes etc

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -50,7 +50,7 @@ div.sidenote{
 	content: " (Next)";
 }
 .later{
-	color: #D3D3D3;
+	color: #909090;
 }
 .later:after{
 	content: " (Coming-Up)";

--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@ Attendance for all contact hours is entirely optional -- however from
 past years experience there is a direct correlation between students who
  attend and those who get over 56% overall.</p>
 
-<h3 name="help">Expectations and Help <a href="#toc" title="return to contents" class="reversefootnote">↩</a></h3>
+<h3 id="help">Expectations and Help <a href="#toc" title="return to contents" class="reversefootnote">↩</a></h3>
 Before we get started on the real UX work let me state the kind of 
 expectations I have of you, and the kind of help that you can get from 
 me. My primary expectation is that you will talk to me, interact, ask 


### PR DESCRIPTION
- Some bulleted list items were still very light and hard to read, so I made them a bit darker
- The "expectations and help" link in the ToC was broken because that section had the `name` attribute set instead of the `id` attribute